### PR TITLE
ignore missing gisaid file

### DIFF
--- a/scripts/recombination/filtering/get_raw_sequences.sh
+++ b/scripts/recombination/filtering/get_raw_sequences.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -ex
+#!/bin/bash -x
 # 
 # Script to retrieve fasta sequences for all nodes in descendants.txt
 


### PR DESCRIPTION
Make get_raw_sequence continue to execute even if gisaid files are missing. Needed for public only mats.