### PR TITLE
Change Ranked_Recomb primary key and avoid sample_descandants duplications

### DIFF
--- a/compare_desc.cpp
+++ b/compare_desc.cpp
@@ -1,0 +1,70 @@
+#include <cstdio>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+typedef std::unordered_map<std::string, std::unordered_set<std::string>> descendant_map_t;
+static void trim(std::string& in){
+    if(in[0]==' '){
+        in=in.substr(1);
+    }
+}
+int main(int argc, char** argv){
+    std::fstream f1(argv[1]);
+    descendant_map_t desc_map;
+    while (f1) {
+        std::string in;
+        std::getline(f1,in);
+        std::stringstream tab_dlim(in);
+        std::string desc;
+        std::getline(tab_dlim,desc,'\t');
+        trim(desc);
+        std::string desc_all;
+        std::getline(tab_dlim,desc_all,'\t');
+        std::stringstream desc_eles(desc_all);
+        std::unordered_set<std::string> descs;
+        while (desc_eles) {
+            std::string desc_name;
+            std::getline(desc_eles,desc_name,',');
+            trim(desc_name);
+            descs.insert(desc_name);
+        }
+        desc_map.emplace(desc,descs);
+    }
+    std::fstream f2(argv[2]);
+    while (f2) {
+        std::string in;
+        std::getline(f2,in);
+        std::stringstream tab_dlim(in);
+        std::string desc;
+        std::getline(tab_dlim,desc,'\t');
+        trim(desc);
+        auto iter=desc_map.find(desc);
+        if (iter==desc_map.end()) {
+            fprintf(stderr, "%s not in first file\n",desc.c_str());
+            continue;
+        }
+        std::string desc_all;
+        std::getline(tab_dlim,desc_all,'\t');
+        std::stringstream desc_eles(desc_all);
+        while (desc_eles) {
+            std::string desc_name;
+            std::getline(desc_eles,desc_name,',');
+            trim(desc_name);
+            auto desc_iter=iter->second.find(desc_name);
+            if (desc_iter==iter->second.end()) {
+                fprintf(stderr, "%s not found as descendat of %s in first file\n", desc_name.c_str(),desc.c_str());
+            }else {
+                iter->second.erase(desc_iter);
+            }
+        }
+        for (const auto& ele : iter->second) {
+                fprintf(stderr, "%s not found as descendat of %s in second file\n", ele.c_str(),desc.c_str());
+        }
+        desc_map.erase(iter);
+    }
+    for (const auto& ele : desc_map) {
+        fprintf(stderr, "%s not in second file\n",ele.first.c_str());
+    }
+}

--- a/src/ripples/post_filtration/get_recomb_info.cpp
+++ b/src/ripples/post_filtration/get_recomb_info.cpp
@@ -1,7 +1,9 @@
 #include "get_recomb_info.hpp"
 #include "src/mutation_annotated_tree.hpp"
 #include "src/ripples/util/text_parser.hpp"
+#include <algorithm>
 #include <boost/algorithm/string/join.hpp>
+#include <boost/iostreams/filter/zlib.hpp>
 #include <ctime>
 #include <fstream>
 #include <iostream>
@@ -12,7 +14,8 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
-
+#include <boost/iostreams/filtering_stream.hpp>
+#include <boost/iostreams/filter/gzip.hpp>
 // Expected format for string date: "2022-08-14"
 // Returns int vector of size 3 [year, month, day]
 std::vector<std::string> format_date(std::string date) {
@@ -60,11 +63,39 @@ int elapsed_days(std::string tree_date,
     // Implicit conversion to int to get elapsed days only
     return std::difftime(date_1, date_2) / (60 * 60 * 24);
 }
+static void write_descendants(const std::unordered_set<std::string>& internal_nodes,
+                                MAT::Tree &T,std::ostream& descendants_outfile,std::ostream& samples_outfile){
+    auto dfs_ordered_nodes=T.depth_first_expansion();
+    std::vector<size_t> to_output_dfs_ids;
+    to_output_dfs_ids.reserve(internal_nodes.size());
+    for (const auto& node_name : internal_nodes) {
+        auto node=T.get_node(node_name);
+        to_output_dfs_ids.push_back(node->dfs_idx);
+    }
+    std::sort(to_output_dfs_ids.begin(),to_output_dfs_ids.end());
+    for (auto node_id : to_output_dfs_ids) {
+        // Get all node descendants, no max
+        auto n=dfs_ordered_nodes[node_id];
+        std::vector<std::string> descendants;
+        descendants.reserve(n->dfs_end_idx-n->dfs_idx);
+        for(size_t idx=n->dfs_idx;idx<n->dfs_end_idx;idx++){
+            if (dfs_ordered_nodes[idx]->is_leaf()) {
+                descendants.push_back(dfs_ordered_nodes[idx]->identifier);
+            }
+        }
+        auto descendants_csl = boost::algorithm::join(descendants, ", ");
+        // 1st Column: node_id
+        descendants_outfile << n->identifier << "\t";
+        // 2nd column: comma separated list of descendants for node_id
+        descendants_outfile << descendants_csl << "\t";
+        // 3rd column: descendant count for node_id
+        descendants_outfile << descendants.size() << "\n";
+        samples_outfile << n->identifier << "\n";
+    }
+}
 static void write_single_recomb(std::ofstream &outfile, const Recombinant &r,
-                                std::unordered_set<std::string> internal_nodes,
+                                std::unordered_set<std::string>& internal_nodes,
                                 MAT::Tree &T,
-                                std::ofstream &descendants_outfile,
-                                std::ofstream &samples_outfile,
                                 float recomb_rank) {
     outfile << r.recomb_node_id << "\t";
 
@@ -86,22 +117,10 @@ static void write_single_recomb(std::ofstream &outfile, const Recombinant &r,
                   << "\n";
         exit(1);
     }
-    //  Write descendants to sample_descendants.tsv out file
-    std::vector<std::string> nodes = {r.recomb_node_id, r.donor_node_id,
-                                      r.acceptor_node_id};
 
-    for (auto &n : nodes) {
-        // Get all node descendants, no max
-        auto descendants = T.get_leaves_ids(n);
-        auto descendants_csl = boost::algorithm::join(descendants, ", ");
-        // 1st Column: node_id
-        descendants_outfile << n << "\t";
-        // 2nd column: comma separated list of descendants for node_id
-        descendants_outfile << descendants_csl << "\t";
-        // 3rd column: descendant count for node_id
-        descendants_outfile << descendants.size() << "\n";
-    }
-
+    internal_nodes.insert(r.recomb_node_id);
+    internal_nodes.insert(r.donor_node_id);
+    internal_nodes.insert(r.acceptor_node_id);
     // Get recomb clade (nextstrain) and lineage (pangolin designation)
     auto recomb_clade = T.get_clade_assignment(recomb, 0);
     auto recomb_lineage = T.get_clade_assignment(recomb, 1);
@@ -131,19 +150,6 @@ static void write_single_recomb(std::ofstream &outfile, const Recombinant &r,
         exit(1);
     }
 
-    // Write all trio nodes to sample nodes file   TODO: Clean up
-    if (internal_nodes.find(r.recomb_node_id) == internal_nodes.end()) {
-        samples_outfile << r.recomb_node_id << "\n";
-        internal_nodes.insert({r.recomb_node_id});
-    }
-    if (internal_nodes.find(r.donor_node_id) == internal_nodes.end()) {
-        samples_outfile << r.donor_node_id << "\n";
-        internal_nodes.insert({r.donor_node_id});
-    }
-    if (internal_nodes.find(r.acceptor_node_id) == internal_nodes.end()) {
-        samples_outfile << r.acceptor_node_id << "\n";
-        internal_nodes.insert({r.acceptor_node_id});
-    }
 
     // Get acceptor clade (nextstrain) and lineage (pangolin
     // designation)
@@ -204,8 +210,13 @@ void write_recombination_list(
         throw std::runtime_error(
             "ERROR: Cannot create sample nodes output file.");
     }
+    std::ofstream descendants_outfile_raw("samples_descendants.txt.gz", std::ios::out | std::ios::binary);
+    boost::iostreams::filtering_streambuf< boost::iostreams::output> outbuf;
+    outbuf.push(boost::iostreams::gzip_compressor(boost::iostreams::gzip::best_compression));
+    outbuf.push(descendants_outfile_raw);
+    std::ostream descendants_outfile(&outbuf);
+
     // Create samples output file with the name and all descendants
-    std::ofstream descendants_outfile{"samples_descendants.txt"};
 
     if (!descendants_outfile) {
         throw std::runtime_error(
@@ -225,9 +236,9 @@ void write_recombination_list(
     for (const auto &rr : ranked_recombs) {
         // Get the Recombinant node and write
         Recombinant r = recombinants.at(rr.recomb_node_id);
-        write_single_recomb(outfile, r, internal_nodes, T, descendants_outfile,
-                            samples_outfile, rr.recomb_rank);
+        write_single_recomb(outfile, r, internal_nodes, T,  rr.recomb_rank);
     }
+    write_descendants(internal_nodes, T, descendants_outfile, samples_outfile);
     /*
     for (const auto &r : filtered_out_recombs) {
         write_single_recomb(outfile, r, internal_nodes, T, descendants_outfile,
@@ -237,7 +248,8 @@ void write_recombination_list(
 
     outfile.close();
     samples_outfile.close();
-    descendants_outfile.close();
+    boost::iostreams::close(outbuf);
+    descendants_outfile_raw.close();
 }
 static Recombinant parse_recomb(text_parser &results) {
     auto recomb_id = std::string{results.get_value(0)};

--- a/src/ripples/post_filtration/get_recomb_info.hpp
+++ b/src/ripples/post_filtration/get_recomb_info.hpp
@@ -3,6 +3,7 @@
 
 #include "src/mutation_annotated_tree.hpp"
 #include "src/ripples/util/text_parser.hpp"
+#include <cstddef>
 #include <math.h>
 
 namespace MAT = Mutation_Annotated_Tree;
@@ -28,9 +29,9 @@ struct Recombinant {
 
 struct Ranked_Recombinant {
     float recomb_rank;
-    std::string recomb_node_id;
+    size_t id;
 
-    Ranked_Recombinant(std::string id) { recomb_node_id = id; }
+    Ranked_Recombinant(size_t id):id(id){}
 };
 
 struct RepresentativeSample {


### PR DESCRIPTION
* Due to possible repeated recomb_id, Ranked_Recomb indexes into recombinations vector using index directly.
* Output sample descendants at the end in DFS order.
* Added compare_desc.cpp to compare two descendants files.